### PR TITLE
Add formatter and publish it as vscode extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,71 +1,16 @@
-# splinter README
+# splinter
 
-This is the README for your extension "splinter". After writing up a brief description, we recommend including the following sections.
+Linter for LaTex scientific reports.
 
 ## Features
 
-Describe specific features of your extension including screenshots of your extension in action. Image paths are relative to this README file.
-
-For example if there is an image subfolder under your extension project workspace:
-
-\!\[feature X\]\(images/feature-x.png\)
-
-> Tip: Many popular extensions utilize animations. This is an excellent way to show off your extension! We recommend short, focused animations that are easy to follow.
-
-## Requirements
-
-If you have any requirements or dependencies, add a section describing those and how to install and configure them.
+- Transforms minus sequences in text into dashes and ranges when needed.
+- Replaces "curved" quotation marks with «angular».
+- Adds/removes spaces before some commands.
+- Makes lists consistent.
 
 ## Extension Settings
 
-Include if your extension adds any VS Code settings through the `contributes.configuration` extension point.
-
-For example:
-
 This extension contributes the following settings:
 
-* `myExtension.enable`: Enable/disable this extension.
-* `myExtension.thing`: Set to `blah` to do something.
-
-## Known Issues
-
-Calling out known issues can help limit users opening duplicate issues against your extension.
-
-## Release Notes
-
-Users appreciate release notes as you update your extension.
-
-### 1.0.0
-
-Initial release of ...
-
-### 1.0.1
-
-Fixed issue #.
-
-### 1.1.0
-
-Added features X, Y, and Z.
-
----
-
-## Following extension guidelines
-
-Ensure that you've read through the extensions guidelines and follow the best practices for creating your extension.
-
-* [Extension Guidelines](https://code.visualstudio.com/api/references/extension-guidelines)
-
-## Working with Markdown
-
-You can author your README using Visual Studio Code. Here are some useful editor keyboard shortcuts:
-
-* Split the editor (`Cmd+\` on macOS or `Ctrl+\` on Windows and Linux).
-* Toggle preview (`Shift+Cmd+V` on macOS or `Shift+Ctrl+V` on Windows and Linux).
-* Press `Ctrl+Space` (Windows, Linux, macOS) to see a list of Markdown snippets.
-
-## For more information
-
-* [Visual Studio Code's Markdown Support](http://code.visualstudio.com/docs/languages/markdown)
-* [Markdown Syntax Reference](https://help.github.com/articles/markdown-basics/)
-
-**Enjoy!**
+* `splinter.listType`: set to `dot` to start items with uppercase and end with dots, set to `semicolon` to start items with lowercase and end with semicolons, last one ends with a dot.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # splinter
 
-Linter for LaTex scientific reports.
+VSCode Linter for LaTex scientific reports.
 
 ## Features
 
@@ -9,8 +9,13 @@ Linter for LaTex scientific reports.
 - Adds/removes spaces before some commands.
 - Makes lists consistent.
 
+## Usage
+
+`Ctrl+Shift+P`, followed by `Format Latex Files`.
+
 ## Extension Settings
 
 This extension contributes the following settings:
 
-* `splinter.listType`: set to `dot` to start items with uppercase and end with dots, set to `semicolon` to start items with lowercase and end with semicolons, last one ends with a dot.
+* `splinter.listType`: set to `dot` for items to start with uppercase and end with dots, set to `semicolon` for items to start with lowercase and end with semicolons (last element will end with dot).
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "splinter",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "splinter",
-      "version": "0.0.1",
+      "version": "1.0.0",
       "devDependencies": {
         "@types/mocha": "^10.0.10",
         "@types/node": "20.x",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "displayName": "Splinter",
   "description": "Linter for LaTex scientific reports.",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "engines": {
     "vscode": "^1.99.0"
   },
@@ -41,7 +41,10 @@
       "properties": {
         "splinter.listType": {
           "type": "string",
-          "enum": ["dot", "semicolon"],
+          "enum": [
+            "dot",
+            "semicolon"
+          ],
           "default": "dot",
           "description": "List item style"
         }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "splinter",
+  "repository": "https://github.com/spisladqo/splinter.git",
   "displayName": "Splinter",
   "description": "Linter for LaTex scientific reports.",
   "version": "0.0.1",
@@ -52,7 +53,7 @@
     "test": "vscode-test"
   },
   "devDependencies": {
-    "@types/vscode": "^1.100.0",
+    "@types/vscode": "^1.99.0",
     "@types/mocha": "^10.0.10",
     "@types/node": "20.x",
     "@typescript-eslint/eslint-plugin": "^8.31.1",

--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
       {
         "id": "latex",
         "aliases": [
-          "Latex"
+          "LaTex"
         ],
         "extensions": [
-          "Latex"
+          "LaTex"
         ]
       }
     ],
@@ -30,7 +30,18 @@
         "command": "extension.formatLatex",
         "title": "Format Latex Files"
       }
-    ]
+    ],
+    "configuration": {
+      "title": "LaTex",
+      "properties": {
+        "splinter.listType": {
+          "type": "string",
+          "enum": ["dot", "semicolon"],
+          "default": "dot",
+          "description": "List item style"
+        }
+      }
+    }
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",

--- a/package.json
+++ b/package.json
@@ -1,32 +1,53 @@
 {
   "name": "splinter",
   "displayName": "Splinter",
-  "description": "A linter for scientific reports at the department of system programming",
+  "description": "Linter for LaTex scientific reports.",
   "version": "0.0.1",
   "engines": {
-    "vscode": "^1.99.3"
+    "vscode": "^1.99.0"
   },
   "categories": [
     "Other"
   ],
-  "activationEvents": [],
-  "main": "./extension.js",
+  "activationEvents": [
+    "onLanguage:foo-lang"
+  ],
+  "main": "./out/extension.js",
   "contributes": {
-    "commands": [{
-      "command": "splinter.helloWorld",
-      "title": "Hello World"
-    }]
+    "languages": [
+      {
+        "id": "latex",
+        "aliases": [
+          "Latex"
+        ],
+        "extensions": [
+          "Latex"
+        ]
+      }
+    ],
+    "commands": [
+      {
+        "command": "extension.formatLatex",
+        "title": "Format Latex Files"
+      }
+    ]
   },
   "scripts": {
-    "lint": "eslint .",
-    "pretest": "npm run lint",
+    "vscode:prepublish": "npm run compile",
+    "compile": "tsc -p ./",
+    "watch": "tsc -watch -p ./",
+    "pretest": "npm run compile && npm run lint",
+    "lint": "eslint src",
     "test": "vscode-test"
   },
   "devDependencies": {
     "@types/vscode": "^1.100.0",
     "@types/mocha": "^10.0.10",
     "@types/node": "20.x",
+    "@typescript-eslint/eslint-plugin": "^8.31.1",
+    "@typescript-eslint/parser": "^8.31.1",
     "eslint": "^9.25.1",
+    "typescript": "^5.8.3",
     "@vscode/test-cli": "^0.0.10",
     "@vscode/test-electron": "^2.5.2"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "splinter",
-  "repository": "https://github.com/spisladqo/splinter.git",
+  "publisher": "spisladqo",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/spisladqo/splinter.git"
+  },
   "displayName": "Splinter",
   "description": "Linter for LaTex scientific reports.",
   "version": "0.0.1",


### PR DESCRIPTION
Add formatter with rules for transforming minuses into dashes and ranges, adding/removing whitespaces around them, and making consistent case and punctuation in lists.

Publish linter as a vscode extension.